### PR TITLE
Allowed single selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A [d3.js](https://d3js.org/) heatmap representing time series data. Inspired by 
 | tooltipUnit | Unit to render on the tooltip, can be object for pluralization control | 'contributions' | no |
 | legendEnabled | Option to render a legend | true | no |
 | onClick | callback function on day click events (see example below) | null | no |
+| singleSelection | Option to only be able to select a single date | false | no |
 | locale | Object to translate every word used, except for tooltipUnit | see below | no |
 
 ### Default locale object

--- a/src/calendar-heatmap-mini.js
+++ b/src/calendar-heatmap-mini.js
@@ -32,7 +32,7 @@ function calendarHeatmapMini() {
   var tooltipEnabled = true;
   var tooltipUnit = 'Event';
   var legendEnabled = true;
-  var singleSelection = false;
+  var singleSelection = true;
   var onClick = null;
   var weekStart = 0; //0 for Sunday, 1 for Monday
   var locale = {

--- a/src/calendar-heatmap-mini.js
+++ b/src/calendar-heatmap-mini.js
@@ -32,6 +32,7 @@ function calendarHeatmapMini() {
   var tooltipEnabled = true;
   var tooltipUnit = 'Event';
   var legendEnabled = true;
+  var singleSelection = false;
   var onClick = null;
   var weekStart = 0; //0 for Sunday, 1 for Monday
   var locale = {
@@ -99,6 +100,12 @@ function calendarHeatmapMini() {
     return chart;
   };
 
+  chart.singleSelection = function (value) {
+    if (!arguments.length) { return singleSelection; }
+    singleSelection = value;
+    return chart;
+  };
+
   chart.locale = function (value) {
     if (!arguments.length) { return locale; }
     locale = value;
@@ -163,6 +170,12 @@ function calendarHeatmapMini() {
 
           if (typeof onClick === 'function') {
             dayRect.on('click', function (d) {
+
+              if (chart.singleSelection()) {
+                // Unselect any previously selected boxes
+                d3.select(chart.selector()).selectAll(".day-cell").style('stroke', null);
+              }
+
               if (selectedDay) {
                 selectedDay.style('stroke', null);
               }


### PR DESCRIPTION
I don't know if this can be useful to someone else, but here it is: when `singleSelection` is set to `true`, only a single date at a time will appear as selected.