### PR TITLE
Fix tooltip hover pointer issue

### DIFF
--- a/src/calendar-heatmap-mini.js
+++ b/src/calendar-heatmap-mini.js
@@ -220,6 +220,8 @@ function calendarHeatmapMini() {
                     return x;
                   })
                   .attr('y', y - 12)
+                  .attr('class', 'day-cell-tooltip-rect')
+                  .style('pointer-events', 'none')
                   .style('stroke-width', '1')
                   .style('stroke', chart.colorRange()[1]);
 


### PR DESCRIPTION
Hey Tony :3 ! There's a pointer-event problem with hovered tooltips. The ol' hover spasm due to the tooltip covering part of the triggering hover element funtimes.